### PR TITLE
fix: Improve database definition

### DIFF
--- a/migrations/20220211171309_primary_key_performace.sql
+++ b/migrations/20220211171309_primary_key_performace.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tweet_sentiment DROP CONSTRAINT tweet_sentiment_id_keyword_key;
+ALTER TABLE tweet_sentiment ADD PRIMARY KEY (keyword, id);

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,7 +1,7 @@
 {
   "db": "PostgreSQL",
-  "1c5a186707f4a2426016b9517e511bc564094e9b4ea8324c8b25cf9037bc71c0": {
-    "query": "SELECT EXISTS (\n\t\t\t\tSELECT keyword FROM tweet_sentiment WHERE keyword = $1\n\t\t\t)",
+  "1ed816a172c5b4b238c1921a9a72418aba9bc595afec07ee6954b56f1b59ba9c": {
+    "query": "SELECT EXISTS (\n\t\t\t\tSELECT 1 FROM tweet_sentiment WHERE keyword = $1\n\t\t\t)",
     "describe": {
       "columns": [
         {

--- a/src/database.rs
+++ b/src/database.rs
@@ -81,7 +81,7 @@ impl SentimentDB {
 	pub async fn exists(&self, keyword: &str) -> Result<bool> {
 		let exists = sqlx::query_scalar!(
 			r#"SELECT EXISTS (
-				SELECT keyword FROM tweet_sentiment WHERE keyword = $1
+				SELECT 1 FROM tweet_sentiment WHERE keyword = $1
 			)"#,
 			keyword
 		)


### PR DESCRIPTION
Use primary key instead of unique constraint and use the right column order.
Find only one row for checking keyword existance.